### PR TITLE
Add item tags for tools & armor on 1.15.2

### DIFF
--- a/src/main/resources/data/fabric/tags/items/axes.json
+++ b/src/main/resources/data/fabric/tags/items/axes.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_axe",
+    "more_gems:tourmaline_axe",
+    "more_gems:amethyst_axe",
+    "more_gems:topaz_axe",
+    "more_gems:alexandrite_axe",
+    "more_gems:corundum_axe",
+    "more_gems:sapphire_axe",
+    "more_gems:ruby_axe",
+    "more_gems:carbonado_axe"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/boots.json
+++ b/src/main/resources/data/fabric/tags/items/boots.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_boots",
+    "more_gems:tourmaline_boots",
+    "more_gems:amethyst_boots",
+    "more_gems:topaz_boots",
+    "more_gems:alexandrite_boots",
+    "more_gems:corundum_boots",
+    "more_gems:sapphire_boots",
+    "more_gems:ruby_boots",
+    "more_gems:carbonado_boots"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/chestplates.json
+++ b/src/main/resources/data/fabric/tags/items/chestplates.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_chestplate",
+    "more_gems:tourmaline_chestplate",
+    "more_gems:amethyst_chestplate",
+    "more_gems:topaz_chestplate",
+    "more_gems:alexandrite_chestplate",
+    "more_gems:corundum_chestplate",
+    "more_gems:sapphire_chestplate",
+    "more_gems:ruby_chestplate",
+    "more_gems:carbonado_chestplate"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/helmets.json
+++ b/src/main/resources/data/fabric/tags/items/helmets.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_helmet",
+    "more_gems:tourmaline_helmet",
+    "more_gems:amethyst_helmet",
+    "more_gems:topaz_helmet",
+    "more_gems:alexandrite_helmet",
+    "more_gems:corundum_helmet",
+    "more_gems:sapphire_helmet",
+    "more_gems:ruby_helmet",
+    "more_gems:carbonado_helmet"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/hoes.json
+++ b/src/main/resources/data/fabric/tags/items/hoes.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_hoe",
+    "more_gems:tourmaline_hoe",
+    "more_gems:amethyst_hoe",
+    "more_gems:topaz_hoe",
+    "more_gems:alexandrite_hoe",
+    "more_gems:corundum_hoe",
+    "more_gems:sapphire_hoe",
+    "more_gems:ruby_hoe",
+    "more_gems:carbonado_hoe"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/leggings.json
+++ b/src/main/resources/data/fabric/tags/items/leggings.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_leggings",
+    "more_gems:tourmaline_leggings",
+    "more_gems:amethyst_leggings",
+    "more_gems:topaz_leggings",
+    "more_gems:alexandrite_leggings",
+    "more_gems:corundum_leggings",
+    "more_gems:sapphire_leggings",
+    "more_gems:ruby_leggings",
+    "more_gems:carbonado_leggings"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/pickaxes.json
+++ b/src/main/resources/data/fabric/tags/items/pickaxes.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_pickaxe",
+    "more_gems:tourmaline_pickaxe",
+    "more_gems:amethyst_pickaxe",
+    "more_gems:topaz_pickaxe",
+    "more_gems:alexandrite_pickaxe",
+    "more_gems:corundum_pickaxe",
+    "more_gems:sapphire_pickaxe",
+    "more_gems:ruby_pickaxe",
+    "more_gems:carbonado_pickaxe"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/shovels.json
+++ b/src/main/resources/data/fabric/tags/items/shovels.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_shovel",
+    "more_gems:tourmaline_shovel",
+    "more_gems:amethyst_shovel",
+    "more_gems:topaz_shovel",
+    "more_gems:alexandrite_shovel",
+    "more_gems:corundum_shovel",
+    "more_gems:sapphire_shovel",
+    "more_gems:ruby_shovel",
+    "more_gems:carbonado_shovel"
+  ]
+}

--- a/src/main/resources/data/fabric/tags/items/swords.json
+++ b/src/main/resources/data/fabric/tags/items/swords.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "more_gems:citrine_sword",
+    "more_gems:tourmaline_sword",
+    "more_gems:amethyst_sword",
+    "more_gems:topaz_sword",
+    "more_gems:alexandrite_sword",
+    "more_gems:corundum_sword",
+    "more_gems:sapphire_sword",
+    "more_gems:ruby_sword",
+    "more_gems:carbonado_sword"
+  ]
+}


### PR DESCRIPTION
I'm the author of [Tiered](https://github.com/Draylar/tiered), which adds attributes/modifiers to tools on 1.15.2. My mod looks in the `fabric` namespace for tool and armor tags for modifiers that affect those 2 categories. I noticed your mod doesn't add armor or tools to these tags, which means the user has to add custom datapacks (or I have to ship your items in my tags). Adding these would fix compatibility between our two mods and compatibility between other mods down the road (and allows users to search things like `#chestplates` in the creative search menu).

Note that Fabric API provides `fabric:swords`, `fabric:axes`, `fabric:pickaxes`, `fabric:hoes`, and `fabric:shovels` as tags. Armor tags aren't in the API yet, but my mod registers it (so you only have to assume the tag exists, and nothing goes wrong if it doesn't). 

Let me know if there's anything else you want me to update for this PR. I made a script for creating the tags, so I can adjust anything quickly. Thanks!
